### PR TITLE
storing output .png as part of product.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+testdata
+config.json

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,3 @@
+{
+    "response": "testdata/response.txt"
+}

--- a/main
+++ b/main
@@ -7,3 +7,18 @@ rm -rf images
 rm -rf images.json
 
 time singularity exec -e docker://brainlife/pythonvtk:1.2 ./plot_response.py
+
+# create product.json
+cat << EOF > product.json
+{
+    "brainlife": [
+        { 
+            "type": "image/png", 
+            "name": "Alignment Check (-x 0.5)",
+            "base64": "$(base64 -w 0 images/response.png)"
+        }
+    ]
+}
+EOF
+
+


### PR DESCRIPTION
I am thinking about deprecating images/png datatype, as it can easily be stored in product.json, or as a secondary output from a validator. 

This PR copies the images/response.png to product.json. I am also planning to work on csd datatype validator, and make plot_response.py part of it so that all CSD output will have this plot generated automatically. 